### PR TITLE
Mn/ts cors cache time error

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Data Source is a JS library meant to help developers access Movable Ink Data Sou
 ## Installation
 Add data sources to your package.json file. In `dependencies` include the following:
 ```
-"data-source.js": "https://github.com/movableink/data-source.js.git#v0.0.5"
+"data-source.js": "https://github.com/movableink/data-source.js.git#v0.0.6"
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-source.js",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,10 @@ export default class DataSource {
 
     const url = `${this.sorcererUrlBase}/${this.key}?${paramStr}`;
     const options = {
+      corsCacheTime : 10 * 1000,
       headers : {}
     };
 
-    options.corsCacheTime = 10 * 1000;
     options.headers['x-reverse-proxy-ttl'] =  options.corsCacheTime / 1000;
     options.headers['x-mi-cbe'] = CD._hashForRequest(url, options);
 


### PR DESCRIPTION
Received the following when trying to pull from v0.0.5: 

```
src/index.ts(22,13): error TS2339: Property 'corsCacheTime' does not exist on type '{ headers: {}; }'.
```

Moving `corsCacheTime` inside of the `const options`.