### PR TITLE
add function that returns all rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-source.js",
-  "version": "0.0.6",
+  "version": "0.1.6",
   "main": "./dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export default class DataSource {
     this.sorcererUrlBase = "https://sorcerer.movableink-templates.com/data_sources";
   }
 
-  getRawData(params: object, cb: Function) {
+  getRawData(params: object, cb?: Function) {
     const paramStr = Object.keys(params).map(key => {
       return key + '=' + params[key];
     }).join('&');
@@ -26,21 +26,11 @@ export default class DataSource {
     return CD.get(url, options, cb);
   }
 
-  async getAllRows(params: object) {
-    const paramStr = Object.keys(params).map(key => {
-      return key + '=' + params[key];
-    }).join('&');
+  getAllRows(params: object) {
+    params['mi_multiple'] = true;
 
-    const url = `${this.sorcererUrlBase}/${this.key}?${paramStr}`;
-    const options = {
-      corsCacheTime : 10 * 1000,
-      headers : {}
-    };
-
-    options.headers['x-reverse-proxy-ttl'] =  options.corsCacheTime / 1000;
-    options.headers['x-mi-cbe'] = CD._hashForRequest(url, options);
-
-    const { data } = await CD.get(url, options);
-    return JSON.parse(data)._meta.all_rows;
+    return this.getRawData(params).then(function(response) {
+      return JSON.parse(response.data);
+    });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,4 +25,21 @@ export default class DataSource {
 
     return CD.get(url, options, cb);
   }
+
+  getAllRows(params: object) {
+    const paramStr = Object.keys(params).map(key => {
+      return key + '=' + params[key];
+    }).join('&');
+
+    const url = `${this.sorcererUrlBase}/${this.key}?${paramStr}`;
+    const options = {
+      corsCacheTime : 10 * 1000,
+      headers : {}
+    };
+
+    options.headers['x-reverse-proxy-ttl'] =  options.corsCacheTime / 1000;
+    options.headers['x-mi-cbe'] = CD._hashForRequest(url, options);
+
+    return CD.get(url, options);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export default class DataSource {
     return CD.get(url, options, cb);
   }
 
-  getAllRows(params: object) {
+  async getAllRows(params: object) {
     const paramStr = Object.keys(params).map(key => {
       return key + '=' + params[key];
     }).join('&');
@@ -40,6 +40,7 @@ export default class DataSource {
     options.headers['x-reverse-proxy-ttl'] =  options.corsCacheTime / 1000;
     options.headers['x-mi-cbe'] = CD._hashForRequest(url, options);
 
-    return CD.get(url, options);
+    const { data } = await CD.get(url, options);
+    return JSON.parse(data)._meta.all_rows;
   }
 }

--- a/test/data-source-test.js
+++ b/test/data-source-test.js
@@ -35,3 +35,16 @@ QUnit.test('getRawData invokes the callback passed in', async function(assert) {
 
   await dataSource.getRawData(keys, callback);
 });
+
+QUnit.test('getAllRows returns an array of csv data source rows', async function(assert) {
+  const response = { "data": '{"_meta": {"all_rows":[["women","amanda","yellow"],["women","stephanie","blue"],["women","claire","green"]]}}'};
+  sinon.stub(CD, 'get').resolves(response);
+
+  const dataSource = new DataSource('some_key');
+  const key = { gender: "women" };
+
+  const expectedRows = [["women","amanda","yellow"],["women","stephanie","blue"],["women","claire","green"]];
+  const actualRows = await dataSource.getAllRows(key);
+
+  assert.propEqual(actualRows, expectedRows);
+});

--- a/test/data-source-test.js
+++ b/test/data-source-test.js
@@ -37,7 +37,7 @@ QUnit.test('getRawData invokes the callback passed in', async function(assert) {
 });
 
 QUnit.test('getAllRows returns an array of csv data source rows', async function(assert) {
-  const response = { "data": '{"_meta": {"all_rows":[["women","amanda","yellow"],["women","stephanie","blue"],["women","claire","green"]]}}'};
+  const response = { "data": '[["women","amanda","yellow"],["women","stephanie","blue"],["women","claire","green"]]'};
   sinon.stub(CD, 'get').resolves(response);
 
   const dataSource = new DataSource('some_key');


### PR DESCRIPTION
## Why do we need this change?

This is part of a larger body of work that will provide a way to retrieve multiple csv rows for a duplicate `targeting_key`. There are two other PRs for [rails](https://github.com/movableink/movableink/pull/3192) and [sorcerer](https://github.com/movableink/sorcerer/pull/68) that will support this behavior. 

`getAllRows` method is almost identical to `getRawData`, but we want to isolate it to a seperate method so we can potentially change how it's implemented.

:house: [ch21841](https://app.clubhouse.io/movableink/story/21841)