### PR TITLE
Add Geolocation Support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Add data sources to your package.json file. In `dependencies` include the follow
 
 The client is meant to be ran in a browser-like environment. The package itself is meant to be imported through ES6 modules.
 
-```js
+```javascript
 import DataSource from "data-source.js"
 ```
 
 ### Fetching data
 
-```js
+```javascript
 const key = "unique_datasource_key";  // pulled from the data sources application
 const targetingKeys = {
 targeting_1: CD.param('targeting_1'),
@@ -40,7 +40,7 @@ data from. You can find this key in the Movable Ink platform.
 
 To fetch multiple rows you can call `getAllRows(targetingKeys)` which will return an array of rows.
 
-```js
+```javascript
 const targetingKeys = { category: 'food' };
 const rows = await source.getAllRows(targetingKeys)
 // [["food", "apple", "banana"], ["food", "cake", "rice"], ["food", "fish", "pasta"]]
@@ -70,7 +70,7 @@ You can include a `headers` option to merge the original headers associated with
 
 #### Example
 
-```js
+```javascript
 const targetingKeys = { category: 'food' };
 const rows = await source.getAllRows(targetingKeys, { headers: true })
 // [
@@ -89,18 +89,38 @@ You can also retrieve rows through our GIS capabilities by providing latitude an
 
 This is assuming a CSV Data Source was created with columns `gap_latitude` and `gap_longitude` specified to be targeted using `latitude` and `longitude` respectively.
 
-```js
+```javascript
 const targetingKeys = { mi_lat: CD.param('mi_lat'), mi_lon: CD.param('mi_lon') };
 const rows = await source.getAllRows(targetingKeys)
 // assuming `mi_lat` and `mi_lon` were 40, -70 respectively
 // [
-//   { store_name: "The Gap Bryant Park", gap_latitude: 40, gap_longitude: -70 },
-//   { store_name: "The Gap Time Square", gap_latitude: 50, gap_longitude: -80 },
-//   { store_name: "The Gap Union Square", gap_latitude: 60, gap_longitude: -90 }
+//   ["The Gap Bryant Park", 40, -70],
+//   ["The Gap Time Square", 50, -80],
+//   ["The Gap Union Square", 60, -90]
 // ]
 ```
 
-You will get back by default the three closest locations sorted by distance. We also support the following params along with `mi_include_headers`:
+`headers` also works:
+
+```javascript
+const targetingKeys = { mi_lat: CD.param('mi_lat'), mi_lon: CD.param('mi_lon') };
+const rows = await source.getAllRows(targetingKeys, { headers: true })
+// assuming `mi_lat` and `mi_lon` were 40, -70 respectively
+// {
+//   values: [
+//     { store_name: "The Gap Bryant Park", gap_latitude: 40, gap_longitude: -70 },
+//     { store_name: "The Gap Time Square", gap_latitude: 50, gap_longitude: -80 },
+//     { store_name: "The Gap Union Square", gap_latitude: 60, gap_longitude: -90 }
+//   ],
+//   _meta: {
+//     geo_columns: { latitude: 'gap_latitude', longitude: 'gap_longitude' }
+//   }
+// }
+```
+
+Note: including `headers: true`, only for geolocation, will change the response type from the default `Array`, to an object. This is so we can nest `_meta` as part of the returned data so that users can build a dynamic map back to the original columns used for `latitude` and `longitude`.
+
+You will get back by default the three closest locations sorted by distance. We also support the following params:
 
 * `mi_limit`: by default this is `3`. You can pass an integer to specify how many locations you would like returned in the payload. The max is `20` and any values sent higher than that will default to `20`
 * `mi_radius`: by default this is not used. You can pass in an integer for `mi_radius` to further trim the results by distance (unit is miles).


### PR DESCRIPTION
We're rolling out geolocation soon, and we want to update `data-source.js` with some documentation on how to go about retrieving rows using latitude and longitude.

Please let us know if there's any questions! Some limitations were purely to reach parity with Local maps, so if there's any concerns about a particular default or limit, we're definitely open for discussing.