### PR TITLE
when installing on studio-framework we get a typescript error due to …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-source.js",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "./dist/index.js",
   "license": "MIT",
   "scripts": {
@@ -22,7 +22,7 @@
     "sinon": "^4.1.2"
   },
   "dependencies": {
-    "typescript": "2.6.1",
+    "typescript": "3.7.4",
     "cropduster": "~5.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,9 +1722,10 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typescript@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+typescript@3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 typescript@^1.8.9:
   version "1.8.10"


### PR DESCRIPTION
…using an old version

## Current Behavior

When trying to install on `studio-framework` we get the following errors: 

```shell
> data-source.js@0.2.1 postinstall /Users/jmills/Sites/MI/jet2/65249/jet2/apps/live-pricing-app-65249/node_modules/data-source.js
> tsc -p ./
../@types/node/repl.d.ts(356,36): error TS1005: '=' expected.
../@types/node/repl.d.ts(362,36): error TS1005: '=' expected.
../@types/node/util.d.ts(21,30): error TS1005: '=' expected.
../@types/node/util.d.ts(183,30): error TS1005: '=' expected.
```


## Why do we need this change?

This will resolve the issue of the above and allow us to install it in `studio-framework` apps

## Implementation Details

Upgrade `typescript` from `2.6.1` to `3.7.4`

#### Dependencies (if any)

:house: [ch32145](https://app.clubhouse.io/movableink/story/32145)
