### PR TITLE
remove getSingleTarget

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,18 @@ Data Source is a JS library meant to help developers access Movable Ink Data Sou
   - [Installation](#installation)
   - [Usage](#usage)
     - [Setup](#setup)
-    - [Fetching data](#fetching-data)
+    - [Fetching data for API and Website Data Sources](#fetching-data-for-api-and-website-data-sources)
+      - [Example:](#example)
     - [Multiple target retrieval for CSV Data Sources](#multiple-target-retrieval-for-csv-data-sources)
-      - [Example](#example)
-      - [Notes on multiple targets body:](#notes-on-multiple-targets-body)
-    - [Single target retrieval for CSV Data Sources](#single-target-retrieval-for-csv-data-sources)
       - [Example](#example-1)
+      - [Notes on multiple targets body:](#notes-on-multiple-targets-body)
     - [Get rows based on geo-location](#get-rows-based-on-geo-location)
       - [Example](#example-2)
       - [Details on how Sorcerer determines priority](#details-on-how-sorcerer-determines-priority)
   - [Publishing package:](#publishing-package)
   - [Changelog](#changelog)
+    - [3.0.0](#300)
+    - [2.0.0](#200)
     - [1.0.0](#100)
     - [0.3.0](#030)
     - [0.2.2](#022)
@@ -195,29 +196,6 @@ Which returns the following:
 
 - CSV rows will always be returned in descending order (last CSV row comes back first)
 
-### Single target retrieval for CSV Data Sources
-
-**_Input:_**
-options (this is optional in case you want to override existing headers or add new ones)
-**_Return value:_** an array of rows matching the set
-
-#### Example
-
-```js
-const options = {
-  method: 'POST', // method has to be POST
-  body: JSON.stringify([
-    {
-      Level: 1,
-      Tier: 'Silver',
-    },
-  ]),
-};
-
-const source = new DataSource('some_key');
-const data = await source.getSingleTarget(options);
-```
-
 ---
 
 ### Get rows based on geo-location
@@ -351,6 +329,10 @@ $ npm publish
 ---
 
 ## Changelog
+
+### 3.0.0
+
+- Remove `getSingleTarget` method
 
 ### 2.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable-internal/data-source.js",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "license": "MIT",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,12 +20,6 @@ export default class DataSource {
     getMultipleTargets(opts?: any): Promise<any>;
     /**
      *
-     * @param set
-     * @param opts
-     */
-    getSingleTarget(opts?: any): Promise<any>;
-    /**
-     *
      * @param params
      * @param opts
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,15 +68,6 @@ export default class DataSource {
 
   /**
    *
-   * @param set
-   * @param opts
-   */
-  getSingleTarget(opts: any = {}) {
-    return this.getMultipleTargets(opts);
-  }
-
-  /**
-   *
    * @param params
    * @param opts
    */

--- a/test/data-source-test.js
+++ b/test/data-source-test.js
@@ -73,38 +73,6 @@ test('getMultipleTargets JSON parses response and returns data', async function 
   CD.get.restore();
 });
 
-test('getSingleTarget returns all rows for a single targeting set', async function (assert) {
-  const response = {
-    data:
-      '[{"Level":"1","Tier":"Silver","Content":"Tom and Jerry"},{"Level":"1","Tier":"Silver","Content":"Peter Pan"}]',
-  };
-
-  sinon.stub(CD, 'get').resolves(response);
-
-  const dataSource = new DataSource('some_key');
-
-  const expectedRows = [
-    { Level: '1', Tier: 'Silver', Content: 'Tom and Jerry' },
-    { Level: '1', Tier: 'Silver', Content: 'Peter Pan' },
-  ];
-
-  const targetingSet = [{ Level: '1', Tier: 'Silver' }];
-  const options = {
-    method: 'POST',
-    body: JSON.stringify(targetingSet),
-  };
-  const actualRows = await dataSource.getSingleTarget(options);
-  assert.propEqual(actualRows, expectedRows);
-
-  const requestMethod = CD.get.args[0][1]['method'];
-  assert.equal(requestMethod, 'POST');
-
-  const postBody = CD.get.args[0][1]['body'];
-  assert.equal(postBody, `[{"Level":"1","Tier":"Silver"}]`);
-
-  CD.get.restore();
-});
-
 test('getLocationTargets appends mi to internal query params and returns all geotargeting rows', async function (assert) {
   const response = {
     data:


### PR DESCRIPTION
## Current Behavior
the `getSingleTarget` method is a wrapper for `getMultipleTargets`. 
Rather than having both lets just remove `getSingleTarget` and make people use `getMultipleTargets` (its the same thing). 

## Why do we need this change?
Just to cause less confusion amongst the users as to what the difference is, since you can just pass through one object into the array of getMultipleTargets.

## Implementation Details
Remove getSingleTarget


#### Dependencies (if any)

:house: [ch53173](https://app.clubhouse.io/movableink/story/53173)
