### PR TITLE
 chore: set char limit on cacheOverride

### DIFF
--- a/src/token-builder/types.js
+++ b/src/token-builder/types.js
@@ -1,7 +1,7 @@
 const ALLOWED_ALGOS = new Set(['sha256', 'sha1', 'md5']);
 const ALLOWED_ENCODINGS = new Set(['hex', 'base64', 'base64url', 'base64percent']);
 
-export const REPLACE_CHAR_LIMIT = 100;
+export const CHAR_LIMIT = 100;
 
 export class TokenBase {
   constructor({ name, cacheOverride = null, skipCache = false }) {
@@ -33,6 +33,10 @@ export class TokenBase {
     if (missingProps.length) {
       this.errors.push(`Missing properties for ${this.type} token: "${missingProps.join(', ')}"`);
     }
+
+    if (typeof this.cacheOverride === 'string' && this.cacheOverride.length > CHAR_LIMIT) {
+      this.errors.push(`cacheOverride cannot be over ${CHAR_LIMIT} characters`);
+    }
   }
 }
 
@@ -55,8 +59,8 @@ export class ReplaceToken extends TokenBase {
 
     if (this.value == undefined) {
       this.errors.push('Token was not instantiated with a replace value');
-    } else if (this.value && this.value.length > REPLACE_CHAR_LIMIT) {
-      this.errors.push(`Replace value exceeds ${REPLACE_CHAR_LIMIT} character limit`);
+    } else if (this.value && this.value.length > CHAR_LIMIT) {
+      this.errors.push(`Replace value exceeds ${CHAR_LIMIT} character limit`);
     }
   };
 }
@@ -80,9 +84,9 @@ export class ReplaceLargeToken extends TokenBase {
 
     if (this.value === null || this.value === undefined) {
       this.errors.push('Token was not instantiated with a replace value');
-    } else if (this.value && this.value.length <= REPLACE_CHAR_LIMIT) {
+    } else if (this.value && this.value.length <= CHAR_LIMIT) {
       this.errors.push(
-        `ReplaceLarge token can only be used when value exceeds ${REPLACE_CHAR_LIMIT} character limit`
+        `ReplaceLarge token can only be used when value exceeds ${CHAR_LIMIT} character limit`
       );
     }
   }

--- a/test/token-builder/request-builder-test.js
+++ b/test/token-builder/request-builder-test.js
@@ -1,5 +1,5 @@
 import { RequestBuilder } from '../../src/token-builder/request-builder';
-import { REPLACE_CHAR_LIMIT } from '../../src/token-builder/types';
+import { CHAR_LIMIT } from '../../src/token-builder/types';
 import {
   ReplaceToken,
   ReplaceLargeToken,
@@ -20,7 +20,7 @@ module('RequestBuilder', function () {
     const replaceLargeToken = new ReplaceLargeToken({
       name: 'band',
       cacheOverride: 'flooding',
-      value: '*'.repeat(REPLACE_CHAR_LIMIT + 1),
+      value: '*'.repeat(CHAR_LIMIT + 1),
       skipCache: true,
     });
 
@@ -73,7 +73,7 @@ module('RequestBuilder', function () {
           name: 'band',
           type: 'replaceLarge',
           cacheOverride: 'flooding',
-          value: '*'.repeat(REPLACE_CHAR_LIMIT + 1),
+          value: '*'.repeat(CHAR_LIMIT + 1),
           skipCache: true,
         },
         {
@@ -156,7 +156,7 @@ module('RequestBuilder', function () {
     const expectedErrors = [
       'Request was not made due to invalid tokens. See validation errors below:',
       'token 1: Missing properties for replace token: "name", Token was not instantiated with a replace value',
-      `token 2: ReplaceLarge token can only be used when value exceeds ${REPLACE_CHAR_LIMIT} character limit`,
+      `token 2: ReplaceLarge token can only be used when value exceeds ${CHAR_LIMIT} character limit`,
       'token 3: Missing properties for secret token: "path"',
       'token 4: Missing properties for hmac token: "name", HMAC algorithm is invalid, HMAC secret name not provided, HMAC encoding is invalid',
       'token 5: SHA1 encoding is invalid, Invalid secret token passed into SHA1 tokens array',

--- a/test/token-builder/types-test.js
+++ b/test/token-builder/types-test.js
@@ -5,7 +5,7 @@ import {
   SecretToken,
   HmacToken,
   Sha1Token,
-  REPLACE_CHAR_LIMIT,
+  CHAR_LIMIT,
 } from '../../src/token-builder/types';
 
 const { test, module } = QUnit;
@@ -53,11 +53,40 @@ module('BaseToken', function () {
     assert.equal(tokenModelWithEmptyName.errors.length, 1);
     assert.equal(tokenModelWithEmptyName.errors[0], 'Missing properties for base token: "name"');
   });
+
+  test('will include an error if cacheOverride is over the character limit', (assert) => {
+    {
+      const options = {
+        name: 'FavoriteBand',
+        type: 'base',
+        cacheOverride: '*'.repeat(CHAR_LIMIT),
+      };
+
+      const token1 = new TokenBase(options);
+      token1.validateOptions();
+
+      assert.equal(token1.errors.length, 0);
+    }
+
+    {
+      const options = {
+        name: 'FavoriteBand',
+        type: 'base',
+        cacheOverride: '*'.repeat(CHAR_LIMIT + 1),
+      };
+
+      const token1 = new TokenBase(options);
+      token1.validateOptions();
+
+      assert.equal(token1.errors.length, 1);
+      assert.equal(token1.errors[0], `cacheOverride cannot be over ${CHAR_LIMIT} characters`);
+    }
+  });
 });
 
 module('ReplaceToken', function () {
   test('can be instantiated with all options', (assert) => {
-    const replaceValue = '*'.repeat(REPLACE_CHAR_LIMIT);
+    const replaceValue = '*'.repeat(CHAR_LIMIT);
 
     const options = {
       name: 'FavoriteBand',
@@ -111,20 +140,17 @@ module('ReplaceToken', function () {
   });
 
   test('will include an error if value is longer than replace character limit', (assert) => {
-    const value = '*'.repeat(REPLACE_CHAR_LIMIT + 1);
+    const value = '*'.repeat(CHAR_LIMIT + 1);
     const tokenModel = new ReplaceToken({ name: 'my token', value });
 
     assert.equal(tokenModel.errors.length, 1);
-    assert.equal(
-      tokenModel.errors[0],
-      `Replace value exceeds ${REPLACE_CHAR_LIMIT} character limit`
-    );
+    assert.equal(tokenModel.errors[0], `Replace value exceeds ${CHAR_LIMIT} character limit`);
   });
 });
 
 module('ReplaceLargeToken', function () {
   test('can be instantiated with all options', (assert) => {
-    const replaceValue = '*'.repeat(REPLACE_CHAR_LIMIT + 1);
+    const replaceValue = '*'.repeat(CHAR_LIMIT + 1);
 
     const options = {
       name: 'FavoriteBand',
@@ -146,7 +172,7 @@ module('ReplaceLargeToken', function () {
   });
 
   test('can be instantiated with default options', (assert) => {
-    const replaceValue = '*'.repeat(REPLACE_CHAR_LIMIT + 1);
+    const replaceValue = '*'.repeat(CHAR_LIMIT + 1);
     const options = {
       name: 'FavoriteBand',
       value: replaceValue,
@@ -178,7 +204,7 @@ module('ReplaceLargeToken', function () {
     assert.equal(tokenModel.errors.length, 1);
     assert.equal(
       tokenModel.errors[0],
-      `ReplaceLarge token can only be used when value exceeds ${REPLACE_CHAR_LIMIT} character limit`
+      `ReplaceLarge token can only be used when value exceeds ${CHAR_LIMIT} character limit`
     );
   });
 });


### PR DESCRIPTION
## Current Behavior
Once the Sorcerer [Token Parser caching PR](https://github.com/movableink/sorcerer/pull/179) is merged, a token's `cacheKeyFragment`will be used to generate the cache key. If provided, the value of the `cacheOverride` property will be set as the `cacheKeyFragment`. `cacheOverride` should have the same character limitation as the `replace` token.


## Why do we need this change?
On the Token Builder side, we can validate the length of `cacheOverride` prior to making a request to sorcerer.


## Implementation Details
Updates `TokenBase`'s `validateOptions` method to push an error if `cacheOverride` is beyond the character limit.


#### Dependencies (if any)

:house: [ch55939](https://app.clubhouse.io/movableink/story/55939)
