### PR TITLE
feat(data-source.js): enhance x-mi-cbe header calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,9 @@ $ npm publish
 ---
 
 ## Changelog
+### 3.2.2
+
+- Updates `x-mi-cbe` header hash calculation to ignore params/tokens passed through `x-cache-ignored-query-params` and `skipCache: true` respectively
 ### 3.2.1
 
 - Runs `yarn upgrade --recursive` to fix CVE vulnerability in sub-dependency and general updates for all sub-dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable-internal/data-source.js",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export default class DataSource {
 
     options['headers']['x-reverse-proxy-ttl'] = options['cacheTime'] / 1000;
     options['headers']['x-mi-cbe'] = isTokenBuilder
-      ? this.generateTokenBuilderHash(params, options)
+      ? this.generateTokenBuilderHash(options)
       : this.generateHash(params, options);
 
     return CD.get(url, options);
@@ -61,10 +61,9 @@ export default class DataSource {
 
   /**
    *
-   * @param params
    * @param options
    */
-  generateTokenBuilderHash(params: TargetingParams, options = {}): number | string {
+  generateTokenBuilderHash(options = {}): number | string {
     options = structuredClone(options);
     const { tokenApiVersion, tokens = [] } = JSON.parse(options['body']);
     const cacheFragments = tokens.map(
@@ -76,7 +75,7 @@ export default class DataSource {
 
     options['body'] = JSON.stringify({ tokenApiVersion, tokens: cacheFragments });
 
-    const cacheString = `${this.key}${JSON.stringify(params)}${JSON.stringify(options)}`;
+    const cacheString = `${this.key}${JSON.stringify(options)}`;
 
     return this.hashString(cacheString);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,14 +46,75 @@ export default class DataSource {
       .join('&');
 
     const url = `${this.sorcererUrlBase}/${this.key}?${paramStr}`;
+    const isTokenBuilder = options['body'] && JSON.parse(options['body']).tokenApiVersion;
 
     options['cacheTime'] = options['cacheTime'] || 10 * 1000;
     options['headers'] = options['headers'] || {};
 
     options['headers']['x-reverse-proxy-ttl'] = options['cacheTime'] / 1000;
-    options['headers']['x-mi-cbe'] = CD._hashForRequest(url, options);
+    options['headers']['x-mi-cbe'] = isTokenBuilder
+      ? this.generateTokenBuilderHash(params, options)
+      : this.generateHash(params, options);
 
     return CD.get(url, options);
+  }
+
+  /**
+   *
+   * @param params
+   * @param options
+   */
+  generateTokenBuilderHash(params: TargetingParams, options = {}): number | string {
+    options = structuredClone(options);
+    const { tokenApiVersion, tokens = [] } = JSON.parse(options['body']);
+    const cacheFragments = tokens.map(
+      (x: { skipCache: boolean; cacheOverride: string; value: string }) => {
+        if (x.skipCache) return true;
+        return x.cacheOverride || x.value;
+      }
+    );
+
+    options['body'] = JSON.stringify({ tokenApiVersion, tokens: cacheFragments });
+
+    const cacheString = `${this.key}${JSON.stringify(params)}${JSON.stringify(options)}`;
+
+    return this.hashString(cacheString);
+  }
+
+  /**
+   *
+   * @param params
+   * @param options
+   */
+  generateHash(params: TargetingParams, options = {}): number | string {
+    params = structuredClone(params); // don't want to modify original params
+    const ignoredParams = options['headers']['x-cache-ignored-query-params'];
+    let cacheString: string;
+
+    if (ignoredParams) {
+      for (const param of ignoredParams.split(',')) {
+        delete params[param];
+      }
+      cacheString = `${this.key}${JSON.stringify(params)}${JSON.stringify(options)}`;
+    } else {
+      cacheString = `${this.key}${JSON.stringify(params)}${JSON.stringify(options)}`;
+    }
+    return this.hashString(cacheString);
+  }
+
+  /**
+   *
+   * @param str
+   */
+  hashString(cacheString: string): number | string {
+    let hash = 0;
+    if (cacheString.length === 0) return hash;
+
+    for (let i = 0; i < cacheString.length; i++) {
+      hash = ((hash << 5) - hash + cacheString.charCodeAt(i)) & 0xffffffff;
+    }
+
+    return hash.toString();
   }
 
   /**

--- a/test/data-source-test.js
+++ b/test/data-source-test.js
@@ -21,6 +21,170 @@ test('getRawData makes a get request through cropduster with query params', func
   CD.get.restore();
 });
 
+test('x-mi-cbe calculation should not use query params passed via the "x-cache-ignored-query-params" header', async function (assert) {
+  sinon.stub(CD, 'get');
+
+  const dataSource = new DataSource('some_key');
+
+  const keysA = {
+    targeting_1: 'hi',
+    targeting_2: 'keys',
+    ignored_param: 'ignore_me',
+  };
+
+  const keysB = {
+    targeting_1: 'hi',
+    targeting_2: 'keys',
+    ignored_param: 'ignore_me_too',
+  };
+
+  const keysC = {
+    targeting_1: 'hi',
+    targeting_2: 'keys',
+  };
+
+  const options = {
+    headers: { 'x-cache-ignored-query-params': 'ignored_param' },
+  };
+
+  await dataSource.getRawData(keysA, options);
+  const hashA = CD.get.args[0][1]['headers']['x-mi-cbe'];
+  delete CD.get.args[0][1]['headers']['x-mi-cbe'];
+
+  await dataSource.getRawData(keysB, options);
+  const hashB = CD.get.args[1][1]['headers']['x-mi-cbe'];
+  delete CD.get.args[1][1]['headers']['x-mi-cbe'];
+
+  await dataSource.getRawData(keysC, options);
+  const hashC = CD.get.args[2][1]['headers']['x-mi-cbe'];
+
+  assert.equal(hashA, hashB, hashC);
+
+  CD.get.restore();
+});
+
+test('x-mi-cbe calculation should be identical if skipCache is set to true', async function (assert) {
+  sinon.stub(CD, 'get');
+
+  const dataSource = new DataSource('some_key');
+
+  const postBodyA = JSON.stringify({
+    tokenApiVersion: 'V1',
+    tokens: [
+      {
+        name: 'FavoriteBand',
+        type: 'replace',
+        cacheOverride: 'Movable Band',
+        value: 'Beatles',
+        skipCache: false,
+      },
+      {
+        name: 'Song',
+        type: 'replace',
+        cacheOverride: '',
+        value: 'Yellow Submarine',
+        skipCache: true,
+      },
+    ],
+  });
+
+  const postBodyB = JSON.stringify({
+    tokenApiVersion: 'V1',
+    tokens: [
+      {
+        name: 'FavoriteBand',
+        type: 'replace',
+        cacheOverride: 'Movable Band',
+        value: 'Beatles',
+        skipCache: false,
+      },
+      {
+        name: 'Song',
+        type: 'replace',
+        cacheOverride: '',
+        value: 'Hey Jude',
+        skipCache: true,
+      },
+    ],
+  });
+
+  const optionsA = { method: 'POST', body: postBodyA };
+  const optionsB = { method: 'POST', body: postBodyB };
+
+  await dataSource.getRawData({}, optionsA);
+  const hashA = CD.get.args[0][1]['headers']['x-mi-cbe'];
+  delete CD.get.args[0][1]['headers']['x-mi-cbe'];
+
+  await dataSource.getRawData({}, optionsB);
+  const hashB = CD.get.args[1][1]['headers']['x-mi-cbe'];
+  delete CD.get.args[1][1]['headers']['x-mi-cbe'];
+
+  assert.equal(hashA, hashB);
+
+  CD.get.restore();
+});
+
+test('multiple instances of a token with identical cache override values should yield an identical x-mi-cbe hash', async function (assert) {
+  sinon.stub(CD, 'get');
+
+  const dataSource = new DataSource('some_key');
+
+  const postBodyA = JSON.stringify({
+    tokenApiVersion: 'V1',
+    tokens: [
+      {
+        name: 'FavoriteBand',
+        type: 'replace',
+        cacheOverride: 'Movable Band',
+        value: 'Beatles',
+        skipCache: false,
+      },
+      {
+        name: 'Song',
+        type: 'replace',
+        cacheOverride: 'override',
+        value: 'Yellow Submarine',
+        skipCache: true,
+      },
+    ],
+  });
+
+  const postBodyB = JSON.stringify({
+    tokenApiVersion: 'V1',
+    tokens: [
+      {
+        name: 'FavoriteBand',
+        type: 'replace',
+        cacheOverride: 'Movable Band',
+        value: 'Rolling Stones',
+        skipCache: false,
+      },
+      {
+        name: 'Song',
+        type: 'replace',
+        cacheOverride: 'override',
+        value: 'Hey Jude',
+        skipCache: true,
+      },
+    ],
+  });
+
+  const optionsA = { method: 'POST', body: postBodyA };
+  const optionsB = { method: 'POST', body: postBodyB };
+
+  await dataSource.getRawData({}, optionsA);
+  const hashA = CD.get.args[0][1]['headers']['x-mi-cbe'];
+  delete CD.get.args[0][1]['headers']['x-mi-cbe'];
+
+  await dataSource.getRawData({}, optionsB);
+  const hashB = CD.get.args[1][1]['headers']['x-mi-cbe'];
+  delete CD.get.args[1][1]['headers']['x-mi-cbe'];
+
+  assert.equal(hashA, hashB);
+
+  CD.get.restore();
+});
+
 test('getRawData will stringify object values in targeting params', function (assert) {
   sinon.stub(CD, 'get');
 
@@ -39,8 +203,7 @@ test('getRawData will stringify object values in targeting params', function (as
 
 test('getMultipleTargets JSON parses response and returns data', async function (assert) {
   const response = {
-    data:
-      '[{"Level":"1","Tier":"Silver","Content":"Tom and Jerry"},{"Level":"2","Tier":"Gold","Content":"Peter Pan"},{"Level":"1","Tier":"Silver","Content":"Marry Poppins"}]',
+    data: '[{"Level":"1","Tier":"Silver","Content":"Tom and Jerry"},{"Level":"2","Tier":"Gold","Content":"Peter Pan"},{"Level":"1","Tier":"Silver","Content":"Marry Poppins"}]',
   };
 
   sinon.stub(CD, 'get').resolves(response);
@@ -75,8 +238,7 @@ test('getMultipleTargets JSON parses response and returns data', async function 
 
 test('getLocationTargets appends mi to internal query params and returns all geotargeting rows', async function (assert) {
   const response = {
-    data:
-      '[{"latitude":"12.34","longitude":"-56.78","name":"Tom and Jerry"},{"latitude":"91.11","longitude":"-12.45","name":"Peter Pan"}]',
+    data: '[{"latitude":"12.34","longitude":"-56.78","name":"Tom and Jerry"},{"latitude":"91.11","longitude":"-12.45","name":"Peter Pan"}]',
   };
 
   sinon.stub(CD, 'get').resolves(response);

--- a/types/cropduster.d.ts
+++ b/types/cropduster.d.ts
@@ -4,7 +4,6 @@ export interface CDResponse {
 
 declare namespace CD {
   function get(url: string, options: Record<string, unknown>): Promise<CDResponse>;
-  function _hashForRequest(url: string, options: Record<string, unknown>): string;
 }
 
 export default CD;


### PR DESCRIPTION
## Current Behavior
The calculation of the `x-mi-cbe` header does not account for  `x-cache-ignored-query-params` or token builder requests that use `skipCache: true`.  This results in a failure requests with the same `cacheKey` to be consistently routed to correct the `sorcerer` machine which result in preventable cache misses.

## Why do we need this change?
We want to improve cache behavior.


## Implementation Details
- Remove the use of `CD._hashForRequest`
- Detect whether the `request` is using Token Builder.
- Add `generateHash` and `generateTokenBuilderHash` methods to remove parameters or tokens we wish to ignore and construct a `cacheString` which we then hash with a new `hashString` method.


#### Dependencies (if any)

:house: [sc77375](https://app.shortcut.com/movableink/story/77375)
