### PR TITLE
Fix incorrect header name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Data Source is a JS library meant to help developers access Movable Ink Data Sou
       - [Details on how Sorcerer determines priority](#details-on-how-sorcerer-determines-priority)
   - [Publishing package:](#publishing-package)
   - [Changelog](#changelog)
+    - [3.2.3](#323)
+    - [3.2.2](#322)
     - [3.2.1](#321)
     - [3.2.0](#320)
     - [3.1.0](#310)
@@ -334,9 +336,15 @@ $ npm publish
 ---
 
 ## Changelog
+
+### 3.2.3
+
+- Fixes `x-mi-cbe` header hash calculation to use correct `x-cache-ignore-query-params` header
+
 ### 3.2.2
 
 - Updates `x-mi-cbe` header hash calculation to ignore params/tokens passed through `x-cache-ignored-query-params` and `skipCache: true` respectively
+
 ### 3.2.1
 
 - Runs `yarn upgrade --recursive` to fix CVE vulnerability in sub-dependency and general updates for all sub-dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable-internal/data-source.js",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export default class DataSource {
    */
   generateHash(params: TargetingParams, options = {}): number | string {
     params = structuredClone(params); // don't want to modify original params
-    const ignoredParams = options['headers']['x-cache-ignored-query-params'] || '';
+    const ignoredParams = options['headers']['x-cache-ignore-query-params'] || '';
 
     for (const param of ignoredParams.split(',')) {
       delete params[param];

--- a/test/data-source-test.js
+++ b/test/data-source-test.js
@@ -21,7 +21,7 @@ test('getRawData makes a get request through cropduster with query params', func
   CD.get.restore();
 });
 
-test('x-mi-cbe calculation should not use query params passed via the "x-cache-ignored-query-params" header', async function (assert) {
+test('x-mi-cbe calculation should not use query params passed via the "x-cache-ignore-query-params" header', async function (assert) {
   sinon.stub(CD, 'get');
 
   const dataSource = new DataSource('some_key');
@@ -44,7 +44,7 @@ test('x-mi-cbe calculation should not use query params passed via the "x-cache-i
   };
 
   const options = {
-    headers: { 'x-cache-ignored-query-params': 'ignored_param' },
+    headers: { 'x-cache-ignore-query-params': 'ignored_param' },
   };
 
   await dataSource.getRawData(keysA, options);
@@ -203,7 +203,8 @@ test('getRawData will stringify object values in targeting params', function (as
 
 test('getMultipleTargets JSON parses response and returns data', async function (assert) {
   const response = {
-    data: '[{"Level":"1","Tier":"Silver","Content":"Tom and Jerry"},{"Level":"2","Tier":"Gold","Content":"Peter Pan"},{"Level":"1","Tier":"Silver","Content":"Marry Poppins"}]',
+    data:
+      '[{"Level":"1","Tier":"Silver","Content":"Tom and Jerry"},{"Level":"2","Tier":"Gold","Content":"Peter Pan"},{"Level":"1","Tier":"Silver","Content":"Marry Poppins"}]',
   };
 
   sinon.stub(CD, 'get').resolves(response);
@@ -238,7 +239,8 @@ test('getMultipleTargets JSON parses response and returns data', async function 
 
 test('getLocationTargets appends mi to internal query params and returns all geotargeting rows', async function (assert) {
   const response = {
-    data: '[{"latitude":"12.34","longitude":"-56.78","name":"Tom and Jerry"},{"latitude":"91.11","longitude":"-12.45","name":"Peter Pan"}]',
+    data:
+      '[{"latitude":"12.34","longitude":"-56.78","name":"Tom and Jerry"},{"latitude":"91.11","longitude":"-12.45","name":"Peter Pan"}]',
   };
 
   sinon.stub(CD, 'get').resolves(response);


### PR DESCRIPTION
## Current Behavior

We are looking for `x-cache-ignored-query-params` header.

## Why do we need this change?

The header is actually called `x-cache-ignore-query-params`.

## Implementation Details

Fix the header name.

#### Dependencies (if any)

🏠 [sc77375](https://app.shortcut.com/movableink/story/77375)
