### PR TITLE
feat: add support for HMAC sha512

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Data Source is a JS library meant to help developers access Movable Ink Data Sou
       - [Details on how Sorcerer determines priority](#details-on-how-sorcerer-determines-priority)
   - [Publishing package:](#publishing-package)
   - [Changelog](#changelog)
+    - [4.1.0](#410)
     - [3.2.3](#323)
     - [3.2.2](#322)
     - [3.2.1](#321)
@@ -336,6 +337,10 @@ $ npm publish
 ---
 
 ## Changelog
+
+### 4.1.0
+
+- allows to pass sha512 algorithm for HMAC token
 
 ### 3.2.3
 

--- a/docs/token-builder.md
+++ b/docs/token-builder.md
@@ -99,7 +99,7 @@ HMAC uses symmetric encryption which means the signature requires a shared secre
 **Params**
 - **options** (required)
   - **stringToSign** (optional) - any string that will be used when generating HMAC signature
-  - **algorithm** (required)- the hashing algorithm: `sha1` , `sha256`, `md5`
+  - **algorithm** (required)- the hashing algorithm: `sha1` , `sha256`, `sha512`, `md5`
   - **secretName** (required) - name of the data source secret (e.g. `watson`)
   - **encoding** (required) - option to encode the signature once it is generated: `hex`, `base64`, `base64url`, `base64percent`
       - `base64url` produces the same result as `base64` but in addition also replaces `+` with `-` , `/` with `_` , and removes the trailing padding character `=`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable-internal/data-source.js",
-  "version": "4.1.0-rc",
+  "version": "4.1.0",
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable-internal/data-source.js",
-  "version": "4.0.0",
+  "version": "4.1.0-rc",
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "license": "MIT",

--- a/src/token-builder/types.js
+++ b/src/token-builder/types.js
@@ -1,4 +1,4 @@
-const ALLOWED_ALGOS = new Set(['sha256', 'sha1', 'md5']);
+const ALLOWED_ALGOS = new Set(['sha256', 'sha1', 'md5', 'sha512']);
 const ALLOWED_ENCODINGS = new Set(['hex', 'base64', 'base64url', 'base64percent']);
 
 export const CHAR_LIMIT = 100;


### PR DESCRIPTION
## Why do we need this change?
SD is trying to generate HMAC with `sha512` algorithm.
Sorcerer supports this, but the front-end (TokenBuilder) fails validation because the algorithm is not  in the `ALLOWED_ALGOS` list.

## Implementation Details
Add it to the list, so the validation succeeds.


#### Dependencies (if any)

:house:[sc121136](https://app.shortcut.com/movableink/story/121136)
